### PR TITLE
Fix build with Boost >= 1.66.0

### DIFF
--- a/include/core/dbus/asio/executor.h
+++ b/include/core/dbus/asio/executor.h
@@ -18,17 +18,11 @@
 #ifndef CORE_DBUS_ASIO_EXECUTOR_H_
 #define CORE_DBUS_ASIO_EXECUTOR_H_
 
+#include <boost/asio/io_service.hpp>
+
 #include <core/dbus/bus.h>
 #include <core/dbus/executor.h>
 #include <core/dbus/visibility.h>
-
-namespace boost
-{
-namespace asio
-{
-class io_service;
-}
-}
 
 namespace core
 {


### PR DESCRIPTION
It should eventually be changed from io_service to io_context (see
https://www.boost.org/doc/libs/1_66_0/doc/html/boost_asio/net_ts.html)
but that's for a different day.